### PR TITLE
revert 0.3.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 8d2a704e8bd6c8b85f43cf919b04f5560b8246e1958dcd9efa9c9e21b755bed9
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - explainerdashboard = explainerdashboard.cli:explainerdashboard_cli
@@ -22,11 +22,10 @@ requirements:
     - pip
     - python >=3.6
   run:
-    - python-graphviz
     - click
     - dash
     - dash-auth
-    - dash-bootstrap-components <=1
+    - dash-bootstrap-components
     - dtreeviz >=1.0
     - flask_simplelogin
     - joblib


### PR DESCRIPTION
Re. #33 (comment)

i'm reverting this back to https://github.com/conda-forge/explainerdashboard-feedstock/commits/master/recipe/meta.yaml
August 3rd version (0.3.6.2).

There was some PR's that pushed to master without bumping the build number (e.g. 497671b#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a)